### PR TITLE
Add tag support to blog posts and implement TagList component

### DIFF
--- a/src/components/BlogPostPreviewCard.astro
+++ b/src/components/BlogPostPreviewCard.astro
@@ -1,5 +1,13 @@
 ---
-const { title, description, heroImage, postUrl } = Astro.props;
+import TagList from './TagList.astro';
+import type { CollectionEntry } from 'astro:content';
+
+interface Props {
+    post: CollectionEntry<'blog'>;
+}
+
+const { post } = Astro.props;
+const { title, description, heroImage, tags = [] } = post.data;
 ---
 
 <style>
@@ -20,11 +28,16 @@ const { title, description, heroImage, postUrl } = Astro.props;
     width: 100%;
     height: auto;
   }
+
+  .post-tags {
+    margin: 1rem 0;
+  }
 </style>
 
 <div class="card">
-  <img src={heroImage} alt={description} />
-  <h3>{title}</h3>
-  <p>{description}</p>
-  <a href={`/blog/${postUrl}/`}>Read More</a>
+    {heroImage && <img src={heroImage} alt={description} />}
+    <h3>{title}</h3>
+    <p>{description}</p>
+    <TagList tags={tags} className="post-tags" />
+    <a href={`/blog/${post.slug}/`}>Read More</a>
 </div>

--- a/src/components/LatestBlogPosts.astro
+++ b/src/components/LatestBlogPosts.astro
@@ -1,7 +1,6 @@
 ---
 import BlogPostPreviewCard from "../components/BlogPostPreviewCard.astro";
 import { getCollection } from "astro:content";
-// Fetch Blog Posts
 
 const posts = (await getCollection("blog")).sort(
   (a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf()
@@ -20,15 +19,8 @@ const posts = (await getCollection("blog")).sort(
 <div class="cardContainer">
   {
     // Render the 3 latest Blog Post Previews
-    posts
-      .slice(-3)
-      .map((post) => (
-        <BlogPostPreviewCard
-          title={post.data.title}
-          description={post.data.description}
-          heroImage={post.data.heroImage}
-          postUrl={post.slug}
-        />
-      ))
+    posts.slice(-3).map((post) => (
+      <BlogPostPreviewCard post={post} />
+    ))
   }
 </div>

--- a/src/components/TagList.astro
+++ b/src/components/TagList.astro
@@ -1,0 +1,41 @@
+---
+interface Props {
+    tags: string[];
+    className?: string;
+}
+
+const { tags, className = '' } = Astro.props;
+---
+<div class:list={['tag-list', className]}>
+    {tags.map((tag) => (
+        <a href={`/tags/${tag}`} class="tag">#{tag}</a>
+    ))}
+</div>
+
+<style>
+    .tag-list {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.5rem;
+    }
+    .tag {
+        display: inline-block;
+        padding: 0.2rem 0.8rem;
+        border-radius: 999px;
+        background-color: var(--tags-bg, #e5e7eb);
+        color: var(--tags-color, #4b5563);
+        font-size: 0.875rem;
+        text-decoration: none;
+        transition: all 0.2s;
+    }
+    .tag:hover {
+        background-color: var(--tags-hover-bg, #d1d5db);
+        color: var(--tags-hover-color, #1f2937);
+    }
+    :global(.dark) .tag {
+        --tags-bg: #374151;
+        --tags-color: #d1d5db;
+        --tags-hover-bg: #4b5563;
+        --tags-hover-color: #f3f4f6;
+    }
+</style>

--- a/src/content/blog/040525-back-to-it.md
+++ b/src/content/blog/040525-back-to-it.md
@@ -3,6 +3,7 @@ title: "Back to Blogging: New Challenges and New Beginnings"
 description: "Reflecting on the past months and diving into my latest project in the telecom sector."
 pubDate: "Feb 4 2025"
 heroImage: "/blog-placeholder-5.jpg"
+tags: ["career", "aws", "telecom", "react", "cloud"]
 ---
 
 ## A Long Overdue Update
@@ -16,7 +17,6 @@ In January 2025, I transitioned to a new project in the telecommunications secto
 One of the exciting aspects of this project is the opportunity to expand my expertise. While I have experience with React for frontend development, the backend is cloud-based on AWS — a platform I am still getting familiar with. Learning AWS is something I’m actively working on, and I look forward to deepening my understanding of its services and best practices.
 
 Another challenge has been adapting to the software development landscape within the telecom industry. Unlike my previous experience in the health sector, where security and compliance were the biggest concerns, this project is still in its early stages. A major focus right now is getting the lay of the land—understanding what data is accessible, what data we need to present, and how we communicate with the business. Navigating this landscape also means identifying key stakeholders, knowing who to talk to for data access, and figuring out the best way to integrate with existing systems. Are there APIs available, or will we need to engineer them from scratch? These are the kinds of questions we are working through, making this an exciting and exploratory phase of the project.
-
 
 ## What’s Next?
 

--- a/src/content/blog/docker-detour.md
+++ b/src/content/blog/docker-detour.md
@@ -3,6 +3,7 @@ title: "Colima: The Docker Detour"
 description: "Overcoming Docker Desktop’s Licensing with Colima"
 pubDate: "Apr 12 2024"
 heroImage: "/blog-placeholder-3.jpg"
+tags: ["docker", "colima", "devops", "macos", "containerization"]
 ---
 
 Encountering the `cannot connect to the docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?` error is almost a rite of passage for those venturing into the world of Docker and containerization. However, you could say the real challenge begins when you face Docker Desktop’s licensing dilemma. Whether you're on a corporate machine, in an environment where Docker Desktop isn’t permitted, or simply wary of license compliance issues, finding an efficient alternative can be daunting.

--- a/src/content/blog/k3s-on-multipass.md
+++ b/src/content/blog/k3s-on-multipass.md
@@ -3,8 +3,8 @@ title: "Setting Up a k3s Cluster on Multipass"
 description: "Explore the setup of a k3s Kubernetes cluster using Multipass, offering a streamlined, resource-efficient environment ideal for Kubernetes experimentation and learning."
 pubDate: "Apr 17 2024"
 heroImage: "/blog-placeholder-5.jpg"
+tags: ["kubernetes", "k3s", "multipass", "devops", "virtualization", "tutorial"]
 ---
-
 
 This guide will walk you through the process of setting up a k3s Kubernetes cluster on Multipass, from creating the virtual machines to deploying k3s and joining the worker nodes to the control plane. The goal is to have an Kubernetes cluster that you can experiment and break without consequence.
 

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -1,16 +1,17 @@
-import { defineCollection, z } from 'astro:content';
+import { defineCollection, z } from "astro:content";
 
 const blog = defineCollection({
-	type: 'content',
-	// Type-check frontmatter using a schema
-	schema: z.object({
-		title: z.string(),
-		description: z.string(),
-		// Transform string to Date object
-		pubDate: z.coerce.date(),
-		updatedDate: z.coerce.date().optional(),
-		heroImage: z.string().optional(),
-	}),
+  type: "content",
+  // Type-check frontmatter using a schema
+  schema: z.object({
+    title: z.string(),
+    description: z.string(),
+    // Transform string to Date object
+    pubDate: z.coerce.date(),
+    updatedDate: z.coerce.date().optional(),
+    heroImage: z.string().optional(),
+    tags: z.array(z.string()).default([]),
+  }),
 });
 
 export const collections = { blog };

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -6,11 +6,20 @@ import Footer from '../components/Footer.astro';
 import FormattedDate from '../components/FormattedDate.astro';
 import TagList from '../components/TagList.astro';
 
-type Props = CollectionEntry<'blog'>;
+type Props = CollectionEntry<'blog'> | {
+  title: string;
+  description: string;
+  pubDate: Date;
+  updatedDate?: Date;
+  heroImage?: string;
+  tags?: string[];
+};
 
-const { data, render } = Astro.props;
-const { title, description, pubDate, updatedDate, heroImage, tags = [] } = data;
-const { Content } = await render();
+const props = Astro.props;
+const { title, description, pubDate, updatedDate, heroImage, tags = [] } = 
+  'data' in props ? props.data : props;
+
+const Content = 'render' in props ? (await props.render()).Content : null;
 ---
 
 <html lang="en">
@@ -84,7 +93,7 @@ const { Content } = await render();
 						</div>
 						<TagList tags={tags} className="post-tags" />
 					</div>
-					<Content />
+					{Content && <Content />}
 				</div>
 			</article>
 		</main>

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -4,10 +4,13 @@ import BaseHead from '../components/BaseHead.astro';
 import Header from '../components/Header.astro';
 import Footer from '../components/Footer.astro';
 import FormattedDate from '../components/FormattedDate.astro';
+import TagList from '../components/TagList.astro';
 
-type Props = CollectionEntry<'blog'>['data'];
+type Props = CollectionEntry<'blog'>;
 
-const { title, description, pubDate, updatedDate, heroImage } = Astro.props;
+const { data, render } = Astro.props;
+const { title, description, pubDate, updatedDate, heroImage, tags = [] } = data;
+const { Content } = await render();
 ---
 
 <html lang="en">
@@ -51,6 +54,10 @@ const { title, description, pubDate, updatedDate, heroImage } = Astro.props;
 			}
 			.last-updated-on {
 				font-style: italic;
+				margin-bottom: 0.5em;
+			}
+			.post-tags {
+				margin: 1rem 0;
 			}
 		</style>
 	</head>
@@ -64,6 +71,7 @@ const { title, description, pubDate, updatedDate, heroImage } = Astro.props;
 				</div>
 				<div class="prose">
 					<div class="title">
+						<h1>{title}</h1>
 						<div class="date">
 							<FormattedDate date={pubDate} />
 							{
@@ -74,10 +82,9 @@ const { title, description, pubDate, updatedDate, heroImage } = Astro.props;
 								)
 							}
 						</div>
-						<h1>{title}</h1>
-						<hr />
+						<TagList tags={tags} className="post-tags" />
 					</div>
-					<slot />
+					<Content />
 				</div>
 			</article>
 		</main>

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -9,12 +9,11 @@ export async function getStaticPaths() {
 		props: post,
 	}));
 }
-type Props = CollectionEntry<'blog'>;
 
+type Props = CollectionEntry<'blog'>;
 const post = Astro.props;
 const { Content } = await post.render();
 ---
-
-<BlogPost {...post.data}>
+<BlogPost {...post}>
 	<Content />
 </BlogPost>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -4,7 +4,7 @@ import Header from "../../components/Header.astro";
 import Footer from "../../components/Footer.astro";
 import { SITE_TITLE, SITE_DESCRIPTION } from "../../consts";
 import { getCollection } from "astro:content";
-import FormattedDate from "../../components/FormattedDate.astro";
+import BlogPostPreviewCard from "../../components/BlogPostPreviewCard.astro";
 
 const posts = (await getCollection("blog")).sort(
 	(a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf(),
@@ -18,70 +18,15 @@ const posts = (await getCollection("blog")).sort(
 		<style>
 			main {
 				width: 960px;
+				max-width: calc(100% - 2em);
+				margin: 0 auto;
+				padding: 3em 1em;
 			}
-			ul {
+			.posts-grid {
 				display: flex;
+				flex-direction: row;
 				flex-wrap: wrap;
-				gap: 2rem;
-				list-style-type: none;
-				margin: 0;
-				padding: 0;
-			}
-			ul li {
-				width: calc(50% - 1rem);
-			}
-			ul li * {
-				text-decoration: none;
-				transition: 0.2s ease;
-			}
-			ul li:first-child {
-				width: 100%;
-				margin-bottom: 1rem;
-				text-align: center;
-			}
-			ul li:first-child img {
-				width: 100%;
-			}
-			ul li:first-child .title {
-				font-size: 2.369rem;
-			}
-			ul li img {
-				margin-bottom: 0.5rem;
-				border-radius: 12px;
-			}
-			ul li a {
-				display: block;
-			}
-			.title {
-				margin: 0;
-				color: var(--text-header);
-				line-height: 1;
-			}
-			.date {
-				margin: 0;
-				color: var(--text);
-			}
-			ul li a:hover h4,
-			ul li a:hover .date {
-				color: rgb(var(--accent));
-			}
-			ul a:hover img {
-				box-shadow: var(--box-shadow);
-			}
-			@media (max-width: 720px) {
-				ul {
-					gap: 0.5em;
-				}
-				ul li {
-					width: 100%;
-					text-align: center;
-				}
-				ul li:first-child {
-					margin-bottom: 0;
-				}
-				ul li:first-child .title {
-					font-size: 1.563em;
-				}
+				justify-content: space-between;
 			}
 		</style>
 	</head>
@@ -89,28 +34,9 @@ const posts = (await getCollection("blog")).sort(
 		<Header />
 		<main>
 			<section>
-				<ul>
-					{
-						posts.map((post) => (
-							<li>
-								<a href={`/blog/${post.slug}/`}>
-									<img
-										width={720}
-										height={360}
-										src={post.data.heroImage}
-										alt=""
-									/>
-									<h4 class="title">{post.data.title}</h4>
-									<p class="date">
-										<FormattedDate
-											date={post.data.pubDate}
-										/>
-									</p>
-								</a>
-							</li>
-						))
-					}
-				</ul>
+				<div class="posts-grid">
+					{posts.map((post) => <BlogPostPreviewCard post={post} />)}
+				</div>
 			</section>
 		</main>
 		<Footer />

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -1,0 +1,57 @@
+---
+import { getCollection } from 'astro:content';
+import BaseHead from '../../components/BaseHead.astro';
+import Header from '../../components/Header.astro';
+import Footer from '../../components/Footer.astro';
+import BlogPostPreviewCard from '../../components/BlogPostPreviewCard.astro';
+import { SITE_TITLE, SITE_DESCRIPTION } from '../../consts';
+
+export async function getStaticPaths() {
+    const posts = await getCollection('blog');
+    const tags = [...new Set(posts.flatMap(post => post.data.tags || []))];
+    
+    return tags.map(tag => ({
+        params: { tag },
+        props: {
+            posts: posts.filter(post => post.data.tags?.includes(tag)),
+            tag
+        },
+    }));
+}
+
+const { tag } = Astro.params;
+const { posts } = Astro.props;
+---
+
+<html lang="en">
+	<head>
+		<BaseHead title={`Posts tagged with #${tag} | ${SITE_TITLE}`} description={SITE_DESCRIPTION} />
+	</head>
+	<body>
+		<Header />
+		<main>
+			<h1>Posts tagged with #{tag}</h1>
+			<section>
+				{posts.map((post) => <BlogPostPreviewCard post={post} />)}
+			</section>
+		</main>
+		<Footer />
+	</body>
+</html>
+
+<style>
+	main {
+		width: 960px;
+		max-width: calc(100% - 2em);
+		margin: 0 auto;
+		padding: 3em 1em;
+	}
+	h1 {
+		margin-bottom: 2em;
+	}
+	section {
+		display: grid;
+		grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+		gap: 2rem;
+	}
+</style>


### PR DESCRIPTION
This pull request includes several changes to enhance the blog functionality by introducing a tagging system, updating components to support the new tags, and creating a new page for displaying posts by tag. The most important changes are outlined below:

### Enhancements to BlogPostPreviewCard Component:
* Updated `BlogPostPreviewCard.astro` to use a new `TagList` component and adjusted the props to include post data. [[1]](diffhunk://#diff-ec1bd3e7092aca44bd1bab86934b37dcc4a83896cd77d06ff54e913b1415e639L2-R10) [[2]](diffhunk://#diff-ec1bd3e7092aca44bd1bab86934b37dcc4a83896cd77d06ff54e913b1415e639R31-R42)

### Introduction of TagList Component:
* Added a new `TagList.astro` component to render tags associated with blog posts.

### Updates to Blog Post Data:
* Added tags to the frontmatter of existing blog posts. [[1]](diffhunk://#diff-dd66b6bc4cd500d49a912e4213fa54f709f24567ea459c72c9a21399ba876678R6) [[2]](diffhunk://#diff-b69a6c90406a28928c21e9e3daca3906cf61961548337eebee534ce3733278f7R6) [[3]](diffhunk://#diff-0fb32273840a79f6f1602e9c9752c42dc2cc781d961d93d4742ee5473834d755R6-L8)

### Configuration Changes:
* Updated the blog collection schema in `config.ts` to include a `tags` field. [[1]](diffhunk://#diff-544dcd1cb4d05890db2dcf497052df475216a57683c346216e43133407b7ea58L1-R4) [[2]](diffhunk://#diff-544dcd1cb4d05890db2dcf497052df475216a57683c346216e43133407b7ea58R13)

### New Page for Tag Filtering:
* Created a new `tags/[tag].astro` page to display posts filtered by tag. ([src/pages/tags/[tag].astroR1-R57](diffhunk://#diff-229d812fbe0c6d0e5e270fd92054e3a5bde039f8c8af4dcfd88fcd139cf37d87R1-R57))